### PR TITLE
 use NNI rearrangement as default with ML 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,8 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+paper.md
+paper.bib
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+figure1.png

--- a/R/computePhylo.R
+++ b/R/computePhylo.R
@@ -8,6 +8,7 @@
 #' @param n_threads The number of cpus to use. Just used if nbs > 0.
 #' @param outPrefix A prefix to use on the output files.
 #' @param outDir Where to put the newick files.
+#' @param rearrangement Choice of tree rearrangement, only used if mode="ml".
 #' @param ... Further arguments to pass to \link[phangorn]{optim.pml}.
 #' @details Takes the core gene alignment and produces newick files. If \code{mode}
 #' is set to "nj", the outfile will have a "_nj.nwk" subffix. If set to "ml" and
@@ -34,6 +35,7 @@ computePhylo <- function(ali,
                          n_threads = 1,
                          outPrefix='phylo',
                          outDir='.',
+                         rearrangement='NNI',
                          ...){
 
   outDir <- normalizePath(outDir)
@@ -46,9 +48,16 @@ computePhylo <- function(ali,
 
   if (mode=='ml'){
     nwk <- paste0(outDir, '/', outPrefix, '_ml.nwk')
-    fitNJ <- pml(nj.tree, dat, model='GTR')
+    extras <- match.call(expand.dots = FALSE)$...
+    k <- 1
+    if(length(extras)){
+      if(("optGamma" %in% names(extras) ) & extras$optGamma) k <- 4
+    }
+    fitNJ <- pml(nj.tree, dat, model='GTR', k=k)
+
     fit <- optim.pml(object = fitNJ,
                      model = 'GTR',
+                     rearrangement = rearrangement,
                      ...)
 
     if (nbs > 0L){


### PR DESCRIPTION
Hi  @iferres, 
here are 2 commits, one just tries to avoid some notes from R CMD check. 
The other one is more important. When you optimise the tree with ML you do not generally use any tree rearrangements (in `optim.pml`). I think you should use at least NNI. Also to allow modelling rate variation across sites (`optGamma=TRUE`) you need to set the number of rates in `pml`, I set `k=4` as default as most programs seem to do. Please check that this works as expected. 
Klaus   